### PR TITLE
Fixes double-list styling, other minor tweaks

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -7,7 +7,7 @@ html {
 }
 body {
   margin-bottom: 60px;
-  font-family: 'Lato', sans-sarif;
+  font-family: 'Lato', sans-serif;
 }
 
 a {
@@ -72,27 +72,24 @@ ul.two-columns {
 
   li {
     line-height: 24px;
-    margin-left: $big-spacing;
-    margin-right: -$big-spacing;
+    list-style-position: inside;
     float: left;
     width: 50%;
-
-    &:before {
-      content: '\25CB';
-      font-size: 13px;
-      margin-right: 8px;
-      color: black;
-      font-weight: bold;
-    }
+    padding-left: 24px; // may not match every browser without a CSS reset
   }
 }
 
 ul.inline-items {
-  display: flex;
-  flex-wrap: wrap;
+  margin: 0;
+  padding: 0 0 0 $big-spacing;
   li {
-    width: auto;
-    margin-right: $huge-spacing;
+    list-style: none;
+    display: inline-block;
+    margin-right: $tiny-spacing;
+    margin-bottom: $tiny-spacing;
+    padding: $tiny-spacing $small-spacing;
+    background-color: $tag-bg;
+    border-radius: $tiny-spacing;
   }
 }
 

--- a/app/styles/resume.scss
+++ b/app/styles/resume.scss
@@ -45,8 +45,7 @@ $section-label-width: 150px;
       li {
         display: block;
         width: 50%;
-        padding: .5rem 2rem;
-        padding-right: 1rem;
+        padding: .5rem 1rem .5rem 2rem;
         line-height: 2rem;
         text-transform: uppercase;
         float: left;
@@ -101,9 +100,8 @@ $section-label-width: 150px;
 
     &.header {
       background-color: darken(white, 5%);
-      padding: $default-spacing;
       margin-left: 0;
-      padding-left: $huge-spacing;
+      padding: $default-spacing $default-spacing $default-spacing $huge-spacing;
     }
   }
 
@@ -210,8 +208,8 @@ $section-label-width: 150px;
 
       span.tag, span.trail-tag{
         padding: 1px 2px;
-        background-color: darken(white, 12%);
-        border-radius: 3px;
+        background-color: $tag-bg;
+        border-radius: $tiny-spacing;
         font-size: 12px;
         font-weight: normal;
       }

--- a/app/styles/variables.scss
+++ b/app/styles/variables.scss
@@ -17,6 +17,7 @@ $text-color: #222;
 $bg-color: #f5f5f5;
 $link-color: #337AB7;
 $gray: gray;
+$tag-bg: #EFEFEF;
 
 $sidebar-bgcolor: darken(white, 5%);
 $sidebar-alt-bgcolor: darken(white, 9%);


### PR DESCRIPTION
- Fixed double-circle styling on `ul.two-columns`
- Inline lists are now tag lists, which are easier to scan without the list circle
- Inline tags match the styling of the tag lists
- Other styling cleanup
